### PR TITLE
Fixes #13: Using the Drupal console causes high CPU usage/timeout issues.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "composer/installers": "1.7.0",
         "cweagans/composer-patches": "1.6.7",
         "drupal/core-composer-scaffold": "8.8.2",
-        "drupal/console": "1.0.2",
+        "drupal/console": "1.9.3",
         "drupal/console-dotenv": "0.3.1",
         "drush/drush": "9.7.1",
         "vlucas/phpdotenv": "2.4.0",


### PR DESCRIPTION
Recently it was noticed that there was a CPU utilization issue where running the Drupal console would execute an infinite loop and never actually run. This seems to have likely happened when we pinned drupal/console from `^1.0.2` to `1.0.2`. It turned out that `1.0.2` was actually fairly old and it'd been relying on the `^` to bring in a fix for an infinite loop in finding translations. This pull request brings in the version where the issue was addressed.

**Testing:**
Verify that the drupal console is able to run without extreme CPU utilization.

```
~/example$ lando start
(snipped)

~/example$ lando drupal
Drupal Console version 1.9.3

Usage:
  command [options] [arguments]

Options:
  -h, --help             Display this help message
  -q, --quiet            Do not output any message
  -V, --version          Display this application version
      --ansi             Force ANSI output
      --no-ansi          Disable ANSI output
```
If the issue persists, the Drupal console will not run at all (and the help text will not be shown).