### PR TITLE
Allow Drupal core dependency versions to be set by profile (az-digital/az_quickstart#33, az-digital/az_quickstart#56)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "az-digital/az_quickstart": "dev-master",
         "composer/installers": "1.7.0",
         "cweagans/composer-patches": "1.6.7",
-        "drupal/core-composer-scaffold": "8.8.2",
+        "drupal/core-composer-scaffold": "*",
         "drupal/console": "1.9.3",
         "drupal/console-dotenv": "0.3.1",
         "drush/drush": "9.7.1",
@@ -32,7 +32,7 @@
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "0.5.0",
-        "drupal/core-dev-pinned": "8.8.2",
+        "drupal/core-dev-pinned": "*",
         "mglaman/drupal-check": "1.1.0",
         "pheromone/phpcs-security-audit": "dev-master#1b8a61d4ac8f4f1554bcbf67865f8e1c1b213bdd",
         "sensiolabs/security-checker": "6.0.3"


### PR DESCRIPTION
## Description
Changes version constraints for Drupal core dependencies to be non-specific so versions can be set by profile repo.

## Related Issue
az-digital/az_quickstart#33
az-digital/az_quickstart#56

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
