### PR TITLE
az-digital/az_quickstart#220: Backwards-compatible D9 scaffold repo changes.

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -1,16 +1,15 @@
 name: az_quickstart
 recipe: drupal8
 config:
-  php: '7.2'
+  php: '7.3'
   via: apache:2.4
   webroot: web
   database: mysql:5.7
-  drush: ^9
   xdebug: false
 services:
   appserver:
-    build:
-      - composer global require hirak/prestissimo && composer install -o
+    composer:
+      hirak/prestissimo: ^0.3.9
 tooling:
   # Provide a command to install Drupal.
   # Current versions of the Bitnami MySQL container sometimes signal

--- a/.lando.yml
+++ b/.lando.yml
@@ -10,6 +10,9 @@ services:
   appserver:
     composer:
       hirak/prestissimo: ^0.3.9
+    build:
+      - BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD); if [ $(git ls-remote --heads https://github.com/az-digital/az_quickstart.git $BRANCH_NAME | wc -l) = 1 ]; then PROFILE_BRANCH="$BRANCH_NAME"; else PROFILE_BRANCH=master; fi; composer require --no-update drupal/core-recommended:* zaporylie/composer-drupal-optimizations:* az-digital/az_quickstart:dev-${PROFILE_BRANCH}
+      - composer install -o
 tooling:
   # Provide a command to install Drupal.
   # Current versions of the Bitnami MySQL container sometimes signal

--- a/.probo.yaml
+++ b/.probo.yaml
@@ -1,11 +1,12 @@
-image: proboci/ubuntu-16.04-lamp:php-7.2
+image: proboci/ubuntu:18.04-php7.3
 steps:
   - name: Build Arizona Quickstart
     plugin: Script
     script:
+      - composer self-update
       - composer global require hirak/prestissimo
       - if [ $(git ls-remote --heads https://github.com/az-digital/az_quickstart.git $BRANCH_NAME | wc -l) = 1 ]; then PROFILE_BRANCH="$BRANCH_NAME"; else PROFILE_BRANCH=master; fi
-      - composer require --no-update az-digital/az_quickstart:dev-${PROFILE_BRANCH}
+      - composer require --no-update drupal/core-recommended:* zaporylie/composer-drupal-optimizations:* az-digital/az_quickstart:dev-${PROFILE_BRANCH}
       - composer install -o
   - name: Install Arizona Quickstart
     plugin: Drupal
@@ -13,4 +14,4 @@ steps:
     subDirectory: web
     runInstall: true
     profileName: az_quickstart
-    installArgs: "--site-name='Quickstart Review' --account-name=azadmin --account-pass=probo --verbose"
+    installArgs: "--site-name='Quickstart Review' --account-name=azadmin --account-pass=azadmin --verbose --yes -n"

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "vlucas/phpdotenv": "2.4.0",
         "webflo/drupal-finder": "1.2.0",
         "webmozart/path-util": "2.3.0",
-        "zaporylie/composer-drupal-optimizations": "1.0.0"
+        "zaporylie/composer-drupal-optimizations": "1.1.1"
     },
     "require-dev": {
         "az-digital/az-quickstart-dev": "dev-master"

--- a/scripts/composer/ScriptHandler.php
+++ b/scripts/composer/ScriptHandler.php
@@ -9,6 +9,7 @@ namespace QuickstartProject\composer;
 
 use Composer\Script\Event;
 use Composer\Semver\Comparator;
+use Drupal\Core\Site\Settings;
 use DrupalFinder\DrupalFinder;
 use Symfony\Component\Filesystem\Filesystem;
 use Webmozart\PathUtil\Path;
@@ -36,15 +37,14 @@ class ScriptHandler {
     }
 
     // Prepare the settings file for installation
-    if (!$fs->exists($drupalRoot . '/sites/default/settings.php') and $fs->exists($drupalRoot . '/sites/default/default.settings.php')) {
+    if (!$fs->exists($drupalRoot . '/sites/default/settings.php') && $fs->exists($drupalRoot . '/sites/default/default.settings.php')) {
       $fs->copy($drupalRoot . '/sites/default/default.settings.php', $drupalRoot . '/sites/default/settings.php');
       require_once $drupalRoot . '/core/includes/bootstrap.inc';
       require_once $drupalRoot . '/core/includes/install.inc';
-      $settings['config_directories'] = [
-        CONFIG_SYNC_DIRECTORY => (object) [
-          'value' => Path::makeRelative($drupalFinder->getComposerRoot() . '/config/sync', $drupalRoot),
-          'required' => TRUE,
-        ],
+      new Settings([]);
+      $settings['settings']['config_sync_directory'] = (object) [
+        'value' => Path::makeRelative($drupalFinder->getComposerRoot() . '/config/sync', $drupalRoot),
+        'required' => TRUE,
       ];
       drupal_rewrite_settings($settings, $drupalRoot . '/sites/default/settings.php');
       $fs->chmod($drupalRoot . '/sites/default/settings.php', 0666);


### PR DESCRIPTION
Backwards compatible changes from #21 

- Updates lando, probo configs to be more like profile repo configs and ready for D9
- Updates zaporylie/composer-drupal-optimizations 
- Updates copy of drupal-composer/drupal-project composer script file with latest changes (removes deprecated constant error for D9)