### PR TITLE
Add az-digital fork of pheremone/phpcs-security-audit as repository.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,10 @@
         {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/az-digital/phpcs-security-audit"
         }
     ],
     "require": {


### PR DESCRIPTION
This change is needed in the scaffold repo if we decide to merge az-digital/az-quickstart-dev#4