### PR TITLE
Fixes #28 Fix API rate limit on forked repository

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         },
         {
             "type": "vcs",
-            "url": "https://github.com/az-digital/phpcs-security-audit"
+            "url": "https://github.com/az-digital/phpcs-security-audit",
+            "no-api": true
         }
     ],
     "require": {


### PR DESCRIPTION
**Describe the bug**
After adding in our local fork of `pheromone/phpcs-security-audit` located [here](https://github.com/az-digital/phpcs-security-audit) composer builds in lando are occasionally throwing API rate warnings:

```
GitHub API limit (0 calls/hr) is exhausted, could not fetch https://api.github.com/repos/az-digital/phpcs-security-audit/tags?per_page=100. Create a GitHub OAuth token to go over the API rate limit. You can also wait until ? for the rate limit to reset.
```
**Related Issue**
#28 

**To Test**

1. Test locally
2. Perform local lando builds
3. May take several repetitions, as it's time-limited.
4. Verify that the above error does not occur
