### PR TITLE
Updated 'main' references to '2.0.x'.

### DIFF
--- a/.ddev/commands/web/quickstart-branch
+++ b/.ddev/commands/web/quickstart-branch
@@ -9,4 +9,10 @@ if [ $# -eq 0 ]; then
     exit 0
 fi
 
-composer require --verbose --working-dir="/var/www/html/" "az-digital/az_quickstart:dev-$*"
+if [[ $* =~ ^[0-9]\.[0-9] ]]; then
+  BRANCH="$*-dev"
+else
+  BRANCH="dev-$*"
+fi
+
+composer require --verbose --working-dir="/var/www/html/" "az-digital/az_quickstart:${BRANCH}"

--- a/.lando.yml
+++ b/.lando.yml
@@ -11,7 +11,7 @@ services:
     composer:
       hirak/prestissimo: ^0.3.9
     build:
-      - BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD); if [ $(git ls-remote --heads https://github.com/az-digital/az_quickstart.git $BRANCH_NAME | wc -l) = 1 ]; then PROFILE_BRANCH="$BRANCH_NAME"; else PROFILE_BRANCH=2.0.x; fi; composer require --no-update drupal/core-recommended:* zaporylie/composer-drupal-optimizations:* az-digital/az_quickstart:dev-${PROFILE_BRANCH}
+      - BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD); if [ $(git ls-remote --heads https://github.com/az-digital/az_quickstart.git $BRANCH_NAME | wc -l) = 1 ]; then PROFILE_BRANCH="dev-$BRANCH_NAME"; else PROFILE_BRANCH=2.0.x-dev; fi; composer require --no-update drupal/core-recommended:* zaporylie/composer-drupal-optimizations:* az-digital/az_quickstart:${PROFILE_BRANCH}
       - composer install -o
 tooling:
   # Provide a command to install Drupal.

--- a/.lando.yml
+++ b/.lando.yml
@@ -11,7 +11,7 @@ services:
     composer:
       hirak/prestissimo: ^0.3.9
     build:
-      - BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD); if [ $(git ls-remote --heads https://github.com/az-digital/az_quickstart.git $BRANCH_NAME | wc -l) = 1 ]; then PROFILE_BRANCH="$BRANCH_NAME"; else PROFILE_BRANCH=main; fi; composer require --no-update drupal/core-recommended:* zaporylie/composer-drupal-optimizations:* az-digital/az_quickstart:dev-${PROFILE_BRANCH}
+      - BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD); if [ $(git ls-remote --heads https://github.com/az-digital/az_quickstart.git $BRANCH_NAME | wc -l) = 1 ]; then PROFILE_BRANCH="$BRANCH_NAME"; else PROFILE_BRANCH=2.0.x; fi; composer require --no-update drupal/core-recommended:* zaporylie/composer-drupal-optimizations:* az-digital/az_quickstart:dev-${PROFILE_BRANCH}
       - composer install -o
 tooling:
   # Provide a command to install Drupal.
@@ -33,7 +33,7 @@ tooling:
         interactive:
           type: input
           message: Branch to use, e.g. UADIGITAL-1234.
-          default: main
+          default: 2.0.x
           weight: 600
   # Provide Drush tooling to automatically know the Drupal root.
   drush:

--- a/.probo.yaml
+++ b/.probo.yaml
@@ -4,8 +4,8 @@ steps:
     plugin: Script
     script:
       - composer self-update
-      - if [ $(git ls-remote --heads https://github.com/az-digital/az_quickstart.git $BRANCH_NAME | wc -l) = 1 ]; then PROFILE_BRANCH="$BRANCH_NAME"; else PROFILE_BRANCH=2.0.x; fi
-      - composer require --no-update drupal/core-recommended:* zaporylie/composer-drupal-optimizations:* az-digital/az_quickstart:dev-${PROFILE_BRANCH}
+      - if [ $(git ls-remote --heads https://github.com/az-digital/az_quickstart.git $BRANCH_NAME | wc -l) = 1 ]; then PROFILE_BRANCH="dev-${BRANCH_NAME}"; else PROFILE_BRANCH=2.0.x-dev; fi
+      - composer require --no-update drupal/core-recommended:* zaporylie/composer-drupal-optimizations:* az-digital/az_quickstart:${PROFILE_BRANCH}
       - composer install -o
   - name: Install Arizona Quickstart
     plugin: Drupal

--- a/.probo.yaml
+++ b/.probo.yaml
@@ -4,7 +4,7 @@ steps:
     plugin: Script
     script:
       - composer self-update
-      - if [ $(git ls-remote --heads https://github.com/az-digital/az_quickstart.git $BRANCH_NAME | wc -l) = 1 ]; then PROFILE_BRANCH="$BRANCH_NAME"; else PROFILE_BRANCH=main; fi
+      - if [ $(git ls-remote --heads https://github.com/az-digital/az_quickstart.git $BRANCH_NAME | wc -l) = 1 ]; then PROFILE_BRANCH="$BRANCH_NAME"; else PROFILE_BRANCH=2.0.x; fi
       - composer require --no-update drupal/core-recommended:* zaporylie/composer-drupal-optimizations:* az-digital/az_quickstart:dev-${PROFILE_BRANCH}
       - composer install -o
   - name: Install Arizona Quickstart

--- a/quickstart_branch.sh
+++ b/quickstart_branch.sh
@@ -3,7 +3,7 @@
 # Set the requested quickstart branch of the quickstart composer package.
 
 # Default to the main branch.
-BRANCH="main"
+BRANCH="2.0.x"
 
 # Parse options
 while (( "$#" )); do

--- a/quickstart_branch.sh
+++ b/quickstart_branch.sh
@@ -28,7 +28,11 @@ while (( "$#" )); do
 done
 
 # Compute the expected composer package name of the requested branch.
-BRANCH="dev-${BRANCH}"
+if [[ $BRANCH =~ ^[0-9]\.[0-9] ]]; then
+  BRANCH="${BRANCH}-dev"
+else
+  BRANCH="dev-${BRANCH}"
+fi
 
 # Install and fetch dependencies for the requested branch
 composer require "az-digital/az_quickstart:$BRANCH"


### PR DESCRIPTION
Similar to changes we just made to the probo, lando, and ddev config files in the 2.0.x branch of the profile repo.