### PR TITLE
Updated quickstart-branch scripts to handle strange composer rules for dev prefix/suffix on branch names.

### DIFF
--- a/.ddev/commands/web/quickstart-branch
+++ b/.ddev/commands/web/quickstart-branch
@@ -9,4 +9,10 @@ if [ $# -eq 0 ]; then
     exit 0
 fi
 
-composer require --verbose --working-dir="/var/www/html/" "az-digital/az_quickstart:dev-$*"
+if [[ $* =~ ^[0-9]\.[0-9] ]]; then
+  BRANCH="$*-dev"
+else
+  BRANCH="dev-$*"
+fi
+
+composer require --verbose --working-dir="/var/www/html/" "az-digital/az_quickstart:${BRANCH}"

--- a/quickstart_branch.sh
+++ b/quickstart_branch.sh
@@ -28,7 +28,11 @@ while (( "$#" )); do
 done
 
 # Compute the expected composer package name of the requested branch.
-BRANCH="dev-${BRANCH}"
+if [[ $BRANCH =~ ^[0-9]\.[0-9] ]]; then
+  BRANCH="${BRANCH}-dev"
+else
+  BRANCH="dev-${BRANCH}"
+fi
 
 # Install and fetch dependencies for the requested branch
 composer require "az-digital/az_quickstart:$BRANCH"


### PR DESCRIPTION
From composer documentation:
>In the case of a branch with a version-like name (v1, in this case), you append -dev as a suffix, rather than using dev- as a prefix.

https://getcomposer.org/doc/articles/versions.md#branches

These same changes are also included in #33 for the `2.0.x` branch but it occurred to me that it would probably be best to include these specific changes in both branches.