### PR TITLE
Update drush to 10.3.6 to address Drupal 9.1.x compatibility issue.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "composer/installers": "1.9.0",
         "cweagans/composer-patches": "1.7.0",
         "drupal/core-composer-scaffold": "*",
-        "drush/drush": "10.3.1",
+        "drush/drush": "10.3.6",
         "vlucas/phpdotenv": "2.4.0",
         "webflo/drupal-finder": "1.2.0",
         "webmozart/path-util": "2.3.0",


### PR DESCRIPTION
Updated Drush version to fix Drupal 9.1.x compatibility issue (https://github.com/drush-ops/drush/issues/4580)