### PR TITLE
Fixes az-digital/az-quickstart#699: Add temporary inline require alias for composer security update.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
         "zaporylie/composer-drupal-optimizations": "1.2"
     },
     "require-dev": {
+        "composer/composer": "2.0.13 as 2.0.2",
         "az-digital/az-quickstart-dev": "~1"
     },
     "conflict": {


### PR DESCRIPTION
We tried adding this alias to `az-quickstart-dev` but that didn't work because inline aliases are only supported in root level composer files.