### PR TITLE
az-digital/az_quickstart#712: Remove temporary workaround for composer security update now applied in drupal/core-dev-pinned.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,6 @@
         "zaporylie/composer-drupal-optimizations": "1.2"
     },
     "require-dev": {
-        "composer/composer": "2.0.13 as 2.0.2",
         "az-digital/az-quickstart-dev": "~1"
     },
     "conflict": {


### PR DESCRIPTION
With Drupal 9.1.8, the drupal/core-dev-pinned package is now using a secure version of composer as a dev dependency so we can remove our temporary workaround.