### PR TITLE
Closes #46 Update minimum PHP version.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": ">=7.3",
         "az-digital/az_quickstart": "~2.1",
         "composer/installers": "1.9.0",
         "cweagans/composer-patches": "1.7.0",


### PR DESCRIPTION
az-quickstart-scaffolding/composer.json

Lines 29 to 30 in c3f179b

 "php": ">=7.0", 
 "az-digital/az_quickstart": "~2.1", 
I could be wrong about all of this.

Because we are using the ~ operator in our composer.json for our az-digital/az_quickstart version constraint, the allowed range of installable versions is >=2.1.0 <3.0.0

This means that the earliest tagged version of quickstart that is possible to use with the latest scaffolding repo is 2.1.0-alpha1 which has a core version requirement pinned at "drupal/core-recommended": "9.0.8", and the minimum php version allowed in drupal 9.0.8 is 7.3

https://getcomposer.org/doc/articles/versions.md#tilde-version-range-

It seems as though we may be using an undocumented feature of composer where if you use a tilde and a version number that hasn't been released yet, it just uses any version that matches the requirements?