### PR TITLE
Fixes #48 remove Hirak/Prestissimo.

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -8,8 +8,6 @@ config:
   xdebug: false
 services:
   appserver:
-    composer:
-      hirak/prestissimo: ^0.3.9
     build:
       - BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD); if [ $(git ls-remote --heads https://github.com/az-digital/az_quickstart.git $BRANCH_NAME | wc -l) = 1 ]; then PROFILE_BRANCH="$BRANCH_NAME"; else PROFILE_BRANCH=main; fi; composer require --no-update drupal/core-recommended:* zaporylie/composer-drupal-optimizations:* az-digital/az_quickstart:dev-${PROFILE_BRANCH}
       - composer install -o


### PR DESCRIPTION
On current versions of lando that are using composer 2.0, an attempt to use the Scaffolding's lando file fails with a build step error because Hirak/Prestissimo is not compatible with the 2.0 series of the composer-plugin-api. (and has subsequently been abandoned.)

I think this escaped notice since we don't do Lando builds of the scaffolding very often.

### To verify:

Ensure the following build step failure doesn't happen:

```
Changed current directory to /var/www/.composer

                                                                                                                                             
  [InvalidArgumentException]                                                                                                                 
  Package hirak/prestissimo at version ^0.3.9 has a PHP requirement incompatible with your PHP version, PHP extensions and Composer version 
```