### PR TITLE
Update composer.json to use new Quickstart dev-main branch alias.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     ],
     "require": {
         "php": ">=7.3",
-        "az-digital/az_quickstart": "~2.1",
+        "az-digital/az_quickstart": "~2.2",
         "composer/installers": "1.9.0",
         "cweagans/composer-patches": "1.7.0",
         "drupal/core-composer-scaffold": "*",


### PR DESCRIPTION
Updating scaffolding repo to use updated Quickstart branch alias for `dev-main` (see az-digital/az_quickstart#1264)