### PR TITLE
az-digital/az_quickstart#1367: Update composer.json to use new Quickstart dev-main branch alias.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     ],
     "require": {
         "php": ">=7.3",
-        "az-digital/az_quickstart": "~2.2",
+        "az-digital/az_quickstart": "~2.3",
         "composer/installers": "1.9.0",
         "cweagans/composer-patches": "1.7.0",
         "drupal/core-composer-scaffold": "*",


### PR DESCRIPTION
This should not be merged until _after_ the `2.2.x` branch is created in this repo.