### PR TITLE
az-digital/az_quickstart#1367: 2.2.x branch-specific changes for CI configs.

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -9,7 +9,7 @@ config:
 services:
   appserver:
     build:
-      - BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD); if [ $(git ls-remote --heads https://github.com/az-digital/az_quickstart.git $BRANCH_NAME | wc -l) = 1 ]; then PROFILE_BRANCH="$BRANCH_NAME"; else PROFILE_BRANCH=main; fi; composer require --no-update drupal/core-recommended:* zaporylie/composer-drupal-optimizations:* az-digital/az_quickstart:dev-${PROFILE_BRANCH}
+      - BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD); if [ $(git ls-remote --heads https://github.com/az-digital/az_quickstart.git $BRANCH_NAME | wc -l) = 1 ]; then PROFILE_BRANCH="dev-$BRANCH_NAME"; else PROFILE_BRANCH=2.2.x-dev; fi; composer require --no-update drupal/core-recommended:* zaporylie/composer-drupal-optimizations:* az-digital/az_quickstart:${PROFILE_BRANCH}
       - composer install -o
 tooling:
   # Provide a command to install Drupal.
@@ -31,7 +31,7 @@ tooling:
         interactive:
           type: input
           message: Branch to use, e.g. UADIGITAL-1234.
-          default: main
+          default: 2.2.x
           weight: 600
   # Provide Drush tooling to automatically know the Drupal root.
   drush:

--- a/.probo.yaml
+++ b/.probo.yaml
@@ -4,8 +4,8 @@ steps:
     plugin: Script
     script:
       - composer self-update
-      - if [ $(git ls-remote --heads https://github.com/az-digital/az_quickstart.git $BRANCH_NAME | wc -l) = 1 ]; then PROFILE_BRANCH="$BRANCH_NAME"; else PROFILE_BRANCH=main; fi
-      - composer require --no-update drupal/core-recommended:* zaporylie/composer-drupal-optimizations:* az-digital/az_quickstart:dev-${PROFILE_BRANCH}
+      - if [ $(git ls-remote --heads https://github.com/az-digital/az_quickstart.git $BRANCH_NAME | wc -l) = 1 ]; then PROFILE_BRANCH="dev-${BRANCH_NAME}"; else PROFILE_BRANCH=2.2.x-dev; fi
+      - composer require --no-update drupal/core-recommended:* zaporylie/composer-drupal-optimizations:* az-digital/az_quickstart:${PROFILE_BRANCH}
       - composer install -o
   - name: Install Arizona Quickstart
     plugin: Drupal

--- a/quickstart_branch.sh
+++ b/quickstart_branch.sh
@@ -2,8 +2,8 @@
 #
 # Set the requested quickstart branch of the quickstart composer package.
 
-# Default to the main branch.
-BRANCH="main"
+# Default to the 2.2.x branch.
+BRANCH="2.2.x"
 
 # Parse options
 while (( "$#" )); do


### PR DESCRIPTION
2.2.x branch specific changes needed for CI and local development tool configs. 

The destination branch for this PR should be changed to the 2.2.x branch once it is created. This should only be merged into the 2.2.x branch.