### PR TITLE
Enable dependabot PRs for scaffolding repo pinned dependencies.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "az-digital/developers"
+ 


### PR DESCRIPTION
Would be good to have dependabot generate PRs for this project's dependencies as well.