### PR TITLE
az-digital/az_quickstart#1491: Temporarily remove assset-packagist as composer repo.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,6 @@
             "url": "https://packages.drupal.org/8"
         },
         {
-            "type": "composer",
-            "url": "https://asset-packagist.org"
-        },
-        {
             "type": "vcs",
             "url": "https://github.com/az-digital/phpcs-security-audit",
             "no-api": true


### PR DESCRIPTION
See az-digital/az_quickstart#1491