### PR TITLE
az-digital/az_quickstart#1493: Manual package repo definitions for asset-packagist libraries.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,54 @@
             "type": "vcs",
             "url": "https://github.com/az-digital/phpcs-security-audit",
             "no-api": true
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "bower-asset/chosen",
+                "version": "1.8.7",
+                "type": "drupal-library",
+                "dist": {
+                    "type": "zip",
+                    "url": "https://github.com/harvesthq/chosen-package/archive/refs/tags/v1.8.7.zip"
+                }
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "npm-asset/blazy",
+                "version": "1.8.2",
+                "type": "drupal-library",
+                "dist": {
+                    "type": "zip",
+                    "url": "https://github.com/dinbror/blazy/archive/refs/tags/1.8.2.zip"
+                }
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "npm-asset/jquery-ui-touch-punch",
+                "version": "0.2.3",
+                "type": "drupal-library",
+                "dist": {
+                    "type": "zip",
+                    "url": "https://github.com/furf/jquery-ui-touch-punch/archive/refs/heads/master.zip"
+                }
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "npm-asset/slick-carousel",
+                "version": "1.8.0",
+                "type": "drupal-library",
+                "dist": {
+                    "type": "zip",
+                    "url": "https://github.com/kenwheeler/slick/archive/refs/tags/1.8.0.zip"
+                }
+            }
         }
     ],
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -126,11 +126,7 @@
         },
         "installer-paths": {
             "web/core": ["type:drupal-core"],
-            "web/libraries/{$name}": [
-                "type:bower-asset",
-                "type:drupal-library",
-                "type:npm-asset"
-            ],
+            "web/libraries/{$name}": ["type:drupal-library"],
             "web/modules/contrib/{$name}": ["type:drupal-module"],
             "web/profiles/contrib/{$name}": ["type:drupal-profile"],
             "web/themes/contrib/{$name}": ["type:drupal-theme"],
@@ -139,10 +135,6 @@
             "web/themes/custom/{$name}": ["type:drupal-custom-theme"],
             "drush/Commands/contrib/{$name}": ["type:drupal-drush"]
         },
-        "installer-types": [
-            "bower-asset",
-            "npm-asset"
-        ],
         "drupal-scaffold": {
             "allowed-packages": ["az-digital/az_quickstart"],
             "file-mapping": {


### PR DESCRIPTION
Potential long term solution/replacement for asset-packagist.

Uses approach suggested in Ryan Szrama's blog post that @jwmoore1 found:
https://ryanszrama.com/blog/04-18-2022/replace-asset-packagist-custom-package-repositories 

Relies on the [corresponding profile repo PR](https://github.com/az-digital/az_quickstart/pull/1494).