### PR TITLE
Revert "Prerequisite to address az-digital/az_quickstart#1491: Tempor…arily remove assset-packagist as composer repo. (#60)"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,10 @@
             "url": "https://packages.drupal.org/8"
         },
         {
+            "type": "composer",
+            "url": "https://asset-packagist.org"
+        },
+        {
             "type": "vcs",
             "url": "https://github.com/az-digital/phpcs-security-audit",
             "no-api": true


### PR DESCRIPTION
This reverts commit 39d4545d7541e59438d0bd782ada84c95fcd41c1.