### PR TITLE
Closes #64 Prepare for composer version 2.2.0 upgrade where we need to explicitly allow plugins to run.

### DIFF
--- a/.probo.yaml
+++ b/.probo.yaml
@@ -5,7 +5,7 @@ steps:
     script:
       - composer self-update
       - if [ $(git ls-remote --heads https://github.com/az-digital/az_quickstart.git $BRANCH_NAME | wc -l) = 1 ]; then PROFILE_BRANCH="$BRANCH_NAME"; else PROFILE_BRANCH=main; fi
-      - composer require --no-update drupal/core-recommended:* zaporylie/composer-drupal-optimizations:* az-digital/az_quickstart:dev-${PROFILE_BRANCH}
+      - composer require --no-update drupal/core-recommended:* az-digital/az_quickstart:dev-${PROFILE_BRANCH}
       - composer install -o
   - name: Install Arizona Quickstart
     plugin: Drupal

--- a/composer.json
+++ b/composer.json
@@ -35,8 +35,7 @@
         "oomphinc/composer-installers-extender": "2.0.0",
         "vlucas/phpdotenv": "2.4.0",
         "webflo/drupal-finder": "1.2.0",
-        "webmozart/path-util": "2.3.0",
-        "zaporylie/composer-drupal-optimizations": "1.2"
+        "webmozart/path-util": "2.3.0"
     },
     "require-dev": {
         "az-digital/az-quickstart-dev": "~1"
@@ -78,8 +77,7 @@
         "composer/installers": true,
         "cweagans/composer-patches": true,
         "drupal/core-composer-scaffold": true,
-        "oomphinc/composer-installers-extender": true,
-        "zaporylie/composer-drupal-optimizations": true
+        "oomphinc/composer-installers-extender": true
     },
     "extra": {
         "composer-exit-on-patch-failure": true,

--- a/composer.json
+++ b/composer.json
@@ -74,6 +74,13 @@
             "phpcs -p --colors --standard=web/profiles/custom/az_quickstart/phpcs.xml.dist"
         ]
     },
+    "allow-plugins": {
+        "composer/installers": true,
+        "cweagans/composer-patches": true,
+        "drupal/core-composer-scaffold": true,
+        "oomphinc/composer-installers-extender": true,
+        "zaporylie/composer-drupal-optimizations": true
+    },
     "extra": {
         "composer-exit-on-patch-failure": true,
         "enable-patching": true,


### PR DESCRIPTION
See [getcomposer.org/doc/06-config.md#allow-plugins](https://getcomposer.org/doc/06-config.md#allow-plugins)