### PR TITLE
Closes #66: Increments MariaDB version, Drupal version, removes API version

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,7 +1,6 @@
 
 # Recipe for AZ Quickstart local development
-APIVersion: v1.11.2
-type: drupal8
+type: drupal9
 docroot: web
 php_version: "7.4"
 webserver_type: nginx-fpm
@@ -17,7 +16,7 @@ nfs_mount_enabled: false
 xdebug_enabled: false
 additional_hostnames: []
 additional_fqdns: []
-mariadb_version: "10.2"
+mariadb_version: "10.3"
 provider: default
 use_dns_when_possible: true
 timezone: ""


### PR DESCRIPTION
Closes #66

APIVersion removal per https://github.com/drud/ddev/issues/2116

Tested locally with WSL2.