### PR TITLE
az-digital/az_quickstart#1703 2.4.x release preparations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     ],
     "require": {
         "php": ">=7.3",
-        "az-digital/az_quickstart": "~2.4",
+        "az-digital/az_quickstart": "~2.5",
         "composer/installers": "1.12.0",
         "cweagans/composer-patches": "1.7.0",
         "drupal/core-composer-scaffold": "*",


### PR DESCRIPTION
Update the [az-digital/az_quickstart composer.json requirement](https://github.com/az-digital/az-quickstart-scaffolding/blob/main/composer.json#L30) in the main branch of the az-digital/az_quickstart_scaffolding repo to use new Quickstart dev-main branch alias (~2.5).