### PR TITLE
Closes #85: Backport recent changes into 2.3.x branch.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "cweagans/composer-patches": "1.7.0",
         "drupal/core-composer-scaffold": "*",
         "drush/drush": "10.6.2",
-        "oomphinc/composer-installers-extender": "2.0.0",
+        "oomphinc/composer-installers-extender": "2.0.1",
         "vlucas/phpdotenv": "2.4.0",
         "webflo/drupal-finder": "1.2.2",
         "webmozart/path-util": "2.3.0"

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "drush/drush": "10.3.6",
         "oomphinc/composer-installers-extender": "2.0.0",
         "vlucas/phpdotenv": "2.4.0",
-        "webflo/drupal-finder": "1.2.0",
+        "webflo/drupal-finder": "1.2.2",
         "webmozart/path-util": "2.3.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "composer/installers": "1.12.0",
         "cweagans/composer-patches": "1.7.0",
         "drupal/core-composer-scaffold": "*",
-        "drush/drush": "10.6.2",
+        "drush/drush": "11.0.9",
         "oomphinc/composer-installers-extender": "2.0.1",
         "vlucas/phpdotenv": "2.4.0",
         "webflo/drupal-finder": "1.2.2",

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,16 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "composer/installers": true,
+            "cweagans/composer-patches": true,
+            "drupal/core-composer-scaffold": true,
+            "zaporylie/composer-drupal-optimizations": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "drupal/console-extend-plugin": true,
+            "oomphinc/composer-installers-extender": true
+        }
     },
     "autoload": {
         "classmap": [
@@ -72,12 +81,6 @@
         "phpcs": [
             "phpcs -p --colors --standard=web/profiles/custom/az_quickstart/phpcs.xml.dist"
         ]
-    },
-    "allow-plugins": {
-        "composer/installers": true,
-        "cweagans/composer-patches": true,
-        "drupal/core-composer-scaffold": true,
-        "oomphinc/composer-installers-extender": true
     },
     "extra": {
         "composer-exit-on-patch-failure": true,

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": ">=7.3",
         "az-digital/az_quickstart": "~2.3",
-        "composer/installers": "1.9.0",
+        "composer/installers": "1.12.0",
         "cweagans/composer-patches": "1.7.0",
         "drupal/core-composer-scaffold": "*",
         "drush/drush": "10.6.2",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "composer/installers": "1.9.0",
         "cweagans/composer-patches": "1.7.0",
         "drupal/core-composer-scaffold": "*",
-        "drush/drush": "10.3.6",
+        "drush/drush": "10.6.2",
         "oomphinc/composer-installers-extender": "2.0.0",
         "vlucas/phpdotenv": "2.4.0",
         "webflo/drupal-finder": "1.2.2",


### PR DESCRIPTION
Updates 2.3.x branch with recent changes merged to main.

This change is particularly important because Quickstart 2.3.x PRs are broken without it:
- #79 

We may not want to squash merge this one since I cherry-picked the commits from main.