### PR TITLE
Upgrade Drush for az-digital/az_quickstart#2573

### DIFF
--- a/.probo.yaml
+++ b/.probo.yaml
@@ -16,3 +16,4 @@ steps:
     runInstall: true
     profileName: az_quickstart
     installArgs: "--site-name='Quickstart Review' --account-name=azadmin --account-pass=azadmin --verbose --yes -n"
+    cliDefines: {DRUSH_LAUNCHER_FALLBACK: '$SRC_DIR/vendor/bin/drush'}

--- a/composer.json
+++ b/composer.json
@@ -27,11 +27,11 @@
     ],
     "require": {
         "php": ">=8.1",
-        "az-digital/az_quickstart": "~2.7",
+        "az-digital/az_quickstart": "~2.8",
         "composer/installers": "2.2.0",
         "cweagans/composer-patches": "1.7.3",
         "drupal/core-composer-scaffold": "*",
-        "drush/drush": "^11.6.0",
+        "drush/drush": "^12.1.0",
         "oomphinc/composer-installers-extender": "2.0.1",
         "vlucas/phpdotenv": "2.6.9",
         "webflo/drupal-finder": "1.2.2",


### PR DESCRIPTION
Companion PR for https://github.com/az-digital/az_quickstart/pull/2587

- Upgrades Drush to version 12
- Sets Quickstart requirement to ~2.8 for main branch (this probably should have been changed when we created the 2.7.x release branch)
- Updates probo config so that drush launcher used by Probo can find Drush 12