### PR TITLE
Closes #124 fix order of setup steps, and some code quality and redundancy updates in prepare repo for minor release workflow.

### DIFF
--- a/.github/workflows/prepare-for-minor-release.yml
+++ b/.github/workflows/prepare-for-minor-release.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Create branch from main to prepare for release
         run: |
           git checkout -b prepare-main-for-${{ github.event.client_payload.release_branch_name }}
-          # git push -u origin ${{ github.event.client_payload.release_branch_name }}
+
       - name: Update the az-digital/az_quickstart composer.json requirement on main branch
         run: |
           composer require az-digital/az_quickstart ${{ github.event.client_payload.next_release_branch_alias_constraint }} --no-update --no-scripts --no-interaction

--- a/.github/workflows/prepare-for-minor-release.yml
+++ b/.github/workflows/prepare-for-minor-release.yml
@@ -31,16 +31,6 @@ jobs:
         run: |
           git checkout -b ${{ github.event.client_payload.release_branch_name }}-prepare-for-minor-release
 
-      # - name: Merge `${{ github.event.client_payload.release_branch_name }}-prepare-for-minor-release` branch changes into `main`, then create new release branch
-      #   run: |
-      #     git checkout main
-      #     git merge ${{ github.event.client_payload.release_branch_name }}-prepare-for-minor-release
-      #     git checkout -b ${{ github.event.client_payload.release_branch_name }}
-
-      # - name: Check out new branch so we can make a pull request
-      #   run: |
-      #     git checkout -b ${{ github.event.client_payload.release_branch_name }}-prepare-for-minor-release
-
       - name: Update quickstart_branch.sh in release branch
         run: |
           NEW_VERSION=${{ github.event.client_payload.release_branch_name }}
@@ -83,6 +73,7 @@ jobs:
 
       - name: Checkout az-quickstart-scaffolding
         uses: actions/checkout@v4
+        
       - name: Create branch from main to prepare for release
         run: |
           git checkout -b prepare-main-for-${{ github.event.client_payload.release_branch_name }}

--- a/.github/workflows/prepare-for-minor-release.yml
+++ b/.github/workflows/prepare-for-minor-release.yml
@@ -8,21 +8,21 @@ jobs:
   prepare_for_new_minor_release:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up git
-        run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-
       - name: Setup PHP with composer v2
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.1'
           tools: composer:v2
-        
+
       - name: Checkout az-quickstart-scaffolding
         uses: actions/checkout@v4
 
-      - name: Create new release branch and pushing it back to the repo.
+      - name: Set up git
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+
+      - name: Create new release branch and push it back to the repo.
         run: |
           git checkout -b ${{ github.event.client_payload.release_branch_name }}
           # git push -u origin ${{ github.event.client_payload.release_branch_name }}
@@ -63,7 +63,7 @@ jobs:
           git add quickstart_branch.sh
           git add .lando.yml
           git add .probo.yaml
-          
+
       - name: Add composer.json change to commit for release branch PR
         run: |
           git diff
@@ -89,7 +89,7 @@ jobs:
           git checkout -b prepare-main-for-${{ github.event.client_payload.release_branch_name }}
           # git push -u origin ${{ github.event.client_payload.release_branch_name }}
       - name: Update the az-digital/az_quickstart composer.json requirement on main branch
-        run: | 
+        run: |
           composer require az-digital/az_quickstart ${{ github.event.client_payload.next_release_branch_alias_constraint }} --no-update --no-scripts --no-interaction
 
       - name: Add composer.json change to commit for main branch PR

--- a/.github/workflows/prepare-for-minor-release.yml
+++ b/.github/workflows/prepare-for-minor-release.yml
@@ -81,7 +81,6 @@ jobs:
       #     base: ${{ github.event.client_payload.release_branch_name }}
       #     delete-branch: true
 
-
       - name: Checkout az-quickstart-scaffolding
         uses: actions/checkout@v4
       - name: Create branch from main to prepare for release


### PR DESCRIPTION
It seems that the repo is only cloned and changed directory into in the actions/checkout step.
Remove unneeded step
Remove push existing branch step
