### PR TITLE
#137: Pin drupal/core-composer-scaffold to ^10.1 for 2.8.x.

### DIFF
--- a/.probo.yaml
+++ b/.probo.yaml
@@ -4,10 +4,10 @@ steps:
     plugin: Script
     script:
       - composer self-update
-      - if [ $(git ls-remote --heads https://github.com/az-digital/az_quickstart.git $BRANCH_NAME | wc -l) = 1 ]; then PROFILE_BRANCH="$BRANCH_NAME"; else PROFILE_BRANCH=2.8.x; fi
+      - if [ $(git ls-remote --heads https://github.com/az-digital/az_quickstart.git $BRANCH_NAME | wc -l) = 1 ]; then PROFILE_BRANCH="dev-${BRANCH_NAME}"; else PROFILE_BRANCH=2.8.x-dev; fi
       - if [ $(git ls-remote --heads https://github.com/az-digital/az-quickstart-dev.git $BRANCH_NAME | wc -l) = 1 ]; then DEV_BRANCH="$BRANCH_NAME"; else DEV_BRANCH=main; fi
       - composer require --dev --no-update az-digital/az-quickstart-dev:dev-${DEV_BRANCH}
-      - composer require --no-update drupal/core-recommended:* az-digital/az_quickstart:dev-${PROFILE_BRANCH}
+      - composer require --no-update drupal/core-recommended:* az-digital/az_quickstart:${PROFILE_BRANCH}
       - composer install -o
   - name: Install Arizona Quickstart
     plugin: Drupal

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "az-digital/az_quickstart": "~2.8",
         "composer/installers": "2.2.0",
         "cweagans/composer-patches": "1.7.3",
-        "drupal/core-composer-scaffold": "*",
+        "drupal/core-composer-scaffold": "^10.1",
         "drush/drush": "^12.1.0",
         "oomphinc/composer-installers-extender": "2.0.1",
         "vlucas/phpdotenv": "2.6.9",


### PR DESCRIPTION
Should prevent future PHP errors triggered by composer scripts due to mismatched `drupal/core-composer-scaffold` and `drupal/core-recommended` versions.

Also updates Probo config to work with numeric profile repo branch names (e.g. `2.8.x`).