### PR TITLE
#137: Pin drupal/core-composer-scaffold to ^10.0 for 2.7.x.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "az-digital/az_quickstart": "~2.7",
         "composer/installers": "2.2.0",
         "cweagans/composer-patches": "1.7.3",
-        "drupal/core-composer-scaffold": "*",
+        "drupal/core-composer-scaffold": "^10.0",
         "drush/drush": "^11.6.0",
         "oomphinc/composer-installers-extender": "2.0.1",
         "vlucas/phpdotenv": "2.6.9",


### PR DESCRIPTION
Should prevent future PHP errors triggered by composer scripts due to mismatched `drupal/core-composer-scaffold` and `drupal/core-recommended` versions.