### PR TITLE
az-digital/az_quickstart#3290: Prepare scaffolding repo for Drupal 10.3.x.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,8 +54,7 @@
             "drupal/console-extend-plugin": true,
             "oomphinc/composer-installers-extender": true,
             "php-http/discovery": true,
-            "phpstan/extension-installer": true,
-            "zaporylie/composer-drupal-optimizations": true
+            "phpstan/extension-installer": true
         }
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "az-digital/az_quickstart": "~2.11",
         "composer/installers": "2.2.0",
         "cweagans/composer-patches": "1.7.3",
-        "drupal/core-composer-scaffold": "^10.3",
+        "drupal/core-composer-scaffold": "10.3.0-beta1@beta",
         "drush/drush": "^12.4.3",
         "oomphinc/composer-installers-extender": "2.0.1",
         "vlucas/phpdotenv": "5.6.0",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "az-digital/az_quickstart": "~2.11",
         "composer/installers": "2.2.0",
         "cweagans/composer-patches": "1.7.3",
-        "drupal/core-composer-scaffold": "^10.3@beta",
+        "drupal/core-composer-scaffold": "^10.3",
         "drush/drush": "^12.4.3",
         "oomphinc/composer-installers-extender": "2.0.1",
         "vlucas/phpdotenv": "5.6.0",

--- a/composer.json
+++ b/composer.json
@@ -30,11 +30,11 @@
         "az-digital/az_quickstart": "~2.11",
         "composer/installers": "2.2.0",
         "cweagans/composer-patches": "1.7.3",
-        "drupal/core-composer-scaffold": "10.3.0-beta1",
+        "drupal/core-composer-scaffold": "^10.3",
         "drush/drush": "^12.4.3",
         "oomphinc/composer-installers-extender": "2.0.1",
         "vlucas/phpdotenv": "5.6.0",
-        "webflo/drupal-finder": "1.2.2"
+        "webflo/drupal-finder": "^1.2.2"
     },
     "require-dev": {
         "az-digital/az-quickstart-dev": "~1"

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "az-digital/az_quickstart": "~2.11",
         "composer/installers": "2.2.0",
         "cweagans/composer-patches": "1.7.3",
-        "drupal/core-composer-scaffold": "^10.3",
+        "drupal/core-composer-scaffold": "^10.3@beta",
         "drush/drush": "^12.4.3",
         "oomphinc/composer-installers-extender": "2.0.1",
         "vlucas/phpdotenv": "5.6.0",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "az-digital/az_quickstart": "~2.11",
         "composer/installers": "2.2.0",
         "cweagans/composer-patches": "1.7.3",
-        "drupal/core-composer-scaffold": "^10.2",
+        "drupal/core-composer-scaffold": "10.3.x-dev@dev",
         "drush/drush": "^12.4.3",
         "oomphinc/composer-installers-extender": "2.0.1",
         "vlucas/phpdotenv": "5.6.0",

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,6 @@
             "cweagans/composer-patches": true,
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "drupal/core-composer-scaffold": true,
-            "drupal/console-extend-plugin": true,
             "oomphinc/composer-installers-extender": true,
             "php-http/discovery": true,
             "phpstan/extension-installer": true

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "az-digital/az_quickstart": "~2.11",
         "composer/installers": "2.2.0",
         "cweagans/composer-patches": "1.7.3",
-        "drupal/core-composer-scaffold": "10.3.0-beta1@beta",
+        "drupal/core-composer-scaffold": "10.3.0-beta1",
         "drush/drush": "^12.4.3",
         "oomphinc/composer-installers-extender": "2.0.1",
         "vlucas/phpdotenv": "5.6.0",

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,8 @@
         "webflo/drupal-finder": "^1.2.2"
     },
     "require-dev": {
-        "az-digital/az-quickstart-dev": "~1"
+        "az-digital/az-quickstart-dev": "~1",
+        "drupal/core-dev": "^10.3"
     },
     "conflict": {
         "drupal/drupal": "*"

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "az-digital/az_quickstart": "~2.11",
         "composer/installers": "2.2.0",
         "cweagans/composer-patches": "1.7.3",
-        "drupal/core-composer-scaffold": "10.3.x-dev@dev",
+        "drupal/core-composer-scaffold": "^10.3",
         "drush/drush": "^12.4.3",
         "oomphinc/composer-installers-extender": "2.0.1",
         "vlucas/phpdotenv": "5.6.0",


### PR DESCRIPTION
Changes needed for upgrading Drupal core to 10.3.x.