### PR TITLE
Relax webflo/drupal-finder requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "drush/drush": "^12.4.3",
         "oomphinc/composer-installers-extender": "2.0.1",
         "vlucas/phpdotenv": "5.6.0",
-        "webflo/drupal-finder": "1.2.2"
+        "webflo/drupal-finder": "^1.2.2"
     },
     "require-dev": {
         "az-digital/az-quickstart-dev": "~1"


### PR DESCRIPTION
Pinning to a specific webflo/drupal-finder release is causing compatibility problems with different versions of Drupal core and the Upgrade status module included in our dev dependencies metapackage (see https://github.com/az-digital/az-quickstart-dev/actions/runs/9307170462/job/25801308691?pr=110).  We should make the version constraint more flexible.

Should be backported to 2.10.x, 2.9.x at least.