### PR TITLE
az-digital/az_quickstart#3290: Make 2.10.x branch compatible with switch to drupal/core-dev + fix broken Probo config in 2.10.x branch.

### DIFF
--- a/.probo.yaml
+++ b/.probo.yaml
@@ -4,7 +4,8 @@ steps:
     plugin: Script
     script:
       - composer self-update
-      - if [ $(git ls-remote --heads https://github.com/az-digital/az_quickstart.git $BRANCH_NAME | wc -l) = 1 ]; then PROFILE_BRANCH="dev-${BRANCH_NAME}"; else PROFILE_BRANCH=2.10.x-dev; fi      - if [ $(git ls-remote --heads https://github.com/az-digital/az-quickstart-dev.git $BRANCH_NAME | wc -l) = 1 ]; then DEV_BRANCH="$BRANCH_NAME"; else DEV_BRANCH=main; fi
+      - if [ $(git ls-remote --heads https://github.com/az-digital/az_quickstart.git $BRANCH_NAME | wc -l) = 1 ]; then PROFILE_BRANCH="dev-${BRANCH_NAME}"; else PROFILE_BRANCH=2.10.x-dev; fi
+      - if [ $(git ls-remote --heads https://github.com/az-digital/az-quickstart-dev.git $BRANCH_NAME | wc -l) = 1 ]; then DEV_BRANCH="$BRANCH_NAME"; else DEV_BRANCH=main; fi
       - composer require --dev --no-update az-digital/az-quickstart-dev:dev-${DEV_BRANCH}
       - composer require --no-update drupal/core-recommended:* az-digital/az_quickstart:${PROFILE_BRANCH}
       - composer install -o

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,8 @@
         "webflo/drupal-finder": "1.2.2"
     },
     "require-dev": {
-        "az-digital/az-quickstart-dev": "~1"
+        "az-digital/az-quickstart-dev": "~1",
+        "drupal/core-dev": "^10.2"
     },
     "conflict": {
         "drupal/drupal": "*"


### PR DESCRIPTION
In az-digital/az-quickstart-dev#111 we're planning to replace `drupal/core-dev-pinned` with `drupal/core-dev` so we need to add a core minor version constraint here to ensure the correct version of `drupal/core-dev` is used with this branch.