### PR TITLE
az-digital/az_quickstart#3290: Make 2.9.x branch compatible with switch to drupal/core-dev.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,8 @@
         "webflo/drupal-finder": "1.2.2"
     },
     "require-dev": {
-        "az-digital/az-quickstart-dev": "~1"
+        "az-digital/az-quickstart-dev": "~1",
+        "drupal/core-dev": "^10.2"
     },
     "conflict": {
         "drupal/drupal": "*"


### PR DESCRIPTION
In https://github.com/az-digital/az-quickstart-dev/pull/111 we're planning to replace drupal/core-dev-pinned with drupal/core-dev so we need to add a core minor version constraint here to ensure the correct version of drupal/core-dev is used with this branch.

We'll need to re-run the automated Probo checks for this PR after https://github.com/az-digital/az-quickstart-dev/pull/111 is merged.