### PR TITLE
az-digital/az_quickstart#3581: Fix drupal/core-dev constraint in 2.9.x branch.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     },
     "require-dev": {
         "az-digital/az-quickstart-dev": "~1",
-        "drupal/core-dev": "^10.2"
+        "drupal/core-dev": "~10.2.0"
     },
     "conflict": {
         "drupal/drupal": "*"


### PR DESCRIPTION
Should fix az-digital/az_quickstart#3581

Originated with #155.

We should have used `~10.2.0` as our constraint instead of `^10.2`.  🤦🏻‍♂️ 