### PR TITLE
az-digital/az_quickstart#3581: Fix drupal/core-scaffold and drupal/core-dev constraints in main branch.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     },
     "require-dev": {
         "az-digital/az-quickstart-dev": "~1",
-        "drupal/core-dev": "^10.3"
+        "drupal/core-dev": "~10.3.0"
     },
     "conflict": {
         "drupal/drupal": "*"

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "az-digital/az_quickstart": "~2.12",
         "composer/installers": "2.3.0",
         "cweagans/composer-patches": "1.7.3",
-        "drupal/core-composer-scaffold": "^10.3",
+        "drupal/core-composer-scaffold": "~10.3.0",
         "drush/drush": "^12.4.3",
         "oomphinc/composer-installers-extender": "2.0.1",
         "vlucas/phpdotenv": "5.6.0",


### PR DESCRIPTION
Should prevent az-digital/az_quickstart#3581 from happening again when Drupal 10.4.0 comes out.

Originated with #155.

We should have used `~10.3.0` as our constraint instead of `^10.3`.  🤦🏻‍♂️ 