### PR TITLE
az-digital/az_quickstart#3581: Fix drupal/core-composer-scaffold constraint in 2.10.x branch.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "az-digital/az_quickstart": "~2.10",
         "composer/installers": "2.2.0",
         "cweagans/composer-patches": "1.7.3",
-        "drupal/core-composer-scaffold": "^10.2",
+        "drupal/core-composer-scaffold": "~10.2.0",
         "drush/drush": "^12.4.3",
         "oomphinc/composer-installers-extender": "2.0.1",
         "vlucas/phpdotenv": "5.6.0",


### PR DESCRIPTION
Forgot to also fix `drupal/core-composer-scaffold` constraint.