### PR TITLE
az-digital/az_quickstart#3934: Scaffolding repo changes for Drupal 10.4.x.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "az-digital/az_quickstart": "~2.13",
         "composer/installers": "2.3.0",
         "cweagans/composer-patches": "1.7.3",
-        "drupal/core-composer-scaffold": "~10.3.0",
+        "drupal/core-composer-scaffold": "~10.4.0",
         "drush/drush": "^12.4.3",
         "oomphinc/composer-installers-extender": "2.0.1",
         "vlucas/phpdotenv": "5.6.0",
@@ -38,7 +38,7 @@
     },
     "require-dev": {
         "az-digital/az-quickstart-dev": "~1",
-        "drupal/core-dev": "~10.3.0"
+        "drupal/core-dev": "~10.4.0"
     },
     "conflict": {
         "drupal/drupal": "*"


### PR DESCRIPTION
We already upgraded the main branch of the az_quickstart repo to 10.4.x but haven't yet updated this scaffolding repo.