### PR TITLE
az-digital/az_quickstart#4426: Scaffolding repo updates for Drupal 10.5 (2.x back-port of #200)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "az-digital/az_quickstart": "~2.14",
         "composer/installers": "2.3.0",
         "cweagans/composer-patches": "1.7.3",
-        "drupal/core-composer-scaffold": "~10.4.0",
+        "drupal/core-composer-scaffold": "~10.5.0",
         "drush/drush": "^12.4.3 || ^13.4.0",
         "oomphinc/composer-installers-extender": "2.0.1",
         "vlucas/phpdotenv": "5.6.0",
@@ -38,7 +38,7 @@
     },
     "require-dev": {
         "az-digital/az-quickstart-dev": "~1",
-        "drupal/core-dev": "~10.4.0"
+        "drupal/core-dev": "~10.5.0"
     },
     "conflict": {
         "drupal/drupal": "*"


### PR DESCRIPTION
(cherry picked from commit 0e066eb88c0db549c8e8805dcef0225ead6ead86)

2.x back-port of #200 for az-digital/az_quickstart#4426