### PR TITLE
az-digital/az_quickstart#4446: Update az_quickstart requirement for main branch to ~3.0.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": ">=8.1",
-        "az-digital/az_quickstart": "~2.14",
+        "az-digital/az_quickstart": "~3.0",
         "composer/installers": "2.3.0",
         "cweagans/composer-patches": "1.7.3",
         "drupal/core-composer-scaffold": "~10.5.0",


### PR DESCRIPTION
Looks like we missed a step when updating the Quickstart repos during/after creating the `2.14.x` release branches.

This repo's main branch should have been updated to use `~3.0` as the version requirement for `az-digital/az_quickstart`.  Not sure how we missed this.  We updated the `az-digital/az-quickstart-dev` constraint in #202 but forgot to update the `az-digital/az_quickstart` constraint, I guess.

Currently the `2.x` branch requires a newer version of Quickstart than `main` 😬 :
https://github.com/az-digital/az-quickstart-scaffolding/blob/2.x/composer.json#L30
https://github.com/az-digital/az-quickstart-scaffolding/blob/main/composer.json#L25
