### PR TITLE
Close #253: Upgrade DDEV project type, PHP, and MariaDB versions in config

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,8 +1,8 @@
 
 # Recipe for AZ Quickstart local development
-type: drupal10
+type: drupal11
 docroot: web
-php_version: "8.3"
+php_version: "8.5"
 webserver_type: nginx-fpm
 
 # Default application ports
@@ -16,7 +16,7 @@ nfs_mount_enabled: false
 xdebug_enabled: false
 additional_hostnames: []
 additional_fqdns: []
-mariadb_version: "10.11"
+mariadb_version: "11.8"
 provider: default
 use_dns_when_possible: true
 timezone: ""


### PR DESCRIPTION
Increments versions in DDEV's `config.yaml`:
- type: `drupal10` to `drupal11`
- php_version: `8.3` to `8.5`
- mariadb_version: `10.11` to `11.8`

Testing:
```
git clone https://github.com/az-digital/az-quickstart-scaffolding.git azqs-254
cd azqs-254
git checkout issue/253
ddev config --auto
ddev start
ddev quickstart-install
ddev drush en -y az_demo az_global_footer
```