### PR TITLE
Closes #257: Add temporary workarounds for insecure symfony and twig packages.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "drupal/core-composer-scaffold": "~11.3.0",
         "drush/drush": "^13.6.0",
         "oomphinc/composer-installers-extender": "2.0.1",
+        "symfony/polyfill-intl-idn": "1.38.1 as 1.37.0",
         "vlucas/phpdotenv": "5.6.3",
         "webflo/drupal-finder": "^1.2.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "drush/drush": "^13.6.0",
         "oomphinc/composer-installers-extender": "2.0.1",
         "symfony/polyfill-intl-idn": "1.38.1 as 1.37.0",
+        "twig/twig": "3.27.0 as 3.26.0",
         "vlucas/phpdotenv": "5.6.3",
         "webflo/drupal-finder": "^1.2.2"
     },


### PR DESCRIPTION
https://symfony.com/blog/cve-2026-46644-insecure-equivalence-in-symfony-polyfill-intl-idn-for-ascii-only-xn-labels
https://github.com/twigphp/Twig/releases/tag/v3.27.0

https://www.drupal.org/project/drupal/issues/3592065
https://www.drupal.org/project/drupal/issues/3592382

We'll want to remove this once the next core patch releases come out.