### PR TITLE
Fixes #259 Revert Temporary Scaffolding Workaround (3.4.x backport of #260)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,6 @@
         "drupal/core-composer-scaffold": "~11.3.0",
         "drush/drush": "^13.6.0",
         "oomphinc/composer-installers-extender": "2.0.1",
-        "symfony/polyfill-intl-idn": "1.38.1 as 1.37.0",
-        "twig/twig": "3.27.0 as 3.26.0",
         "vlucas/phpdotenv": "5.6.3",
         "webflo/drupal-finder": "^1.2.2"
     },


### PR DESCRIPTION
This reverts commit 10ee13e8a5c4b0c89fb4808a683f868f45e18716.

(cherry picked from commit 3f45f01b0917543854d29246a1efd854705e22db)